### PR TITLE
fix in profile http toast not to shown

### DIFF
--- a/backend/base/templates/org_profile.html
+++ b/backend/base/templates/org_profile.html
@@ -142,7 +142,7 @@
     toast.style.display = "block";
     setTimeout(() => {
       toast.style.display = "none";
-    }, 2000); // Hide toast after 2 seconds
+    }, 5000); // Increase duration for better visibility
   }
 
   function submitFormData() {
@@ -155,32 +155,32 @@
         "X-CSRFToken": "{{ csrf_token }}",
       },
     })
-      .then((response) => {
-        if (!response.ok) {
-          return response.json().then((data) => {
-            if (data.errors) {
-              displayFormErrors(data.errors);
-              throw new Error(
-                `HTTP error! status: ${response.status}`,
-                displayFormErrors(data.errors)
-              );
-            }
-          });
-        }
-        return response.json();
-      })
-      .then((data) => {
-        if (data.status === "success") {
-          showToast(data.message);
-          setTimeout(() => {
-            window.location.href = "{% url 'organization_locationlist' %}";
-          }, 2000);
-        }
-      })
-      .catch((error) => {
-        console.error("Error:", error);
-        showToast("Error submitting form. " + error.message);
-      });
+    .then((response) => {
+      if (!response.ok) {
+        return response.json().then((data) => {
+          if (data.errors) {
+            displayFormErrors(data.errors);
+          } else {
+            showToast("Error submitting form. Please try again.");
+          }
+        }).catch(() => {
+          showToast("Error processing the response. Please try again.");
+        });
+      }
+      return response.json();
+    })
+    .then((data) => {
+      if (data && data.status === "success") {
+        showToast(data.message);
+        setTimeout(() => {
+          window.location.href = "{% url 'organization_locationlist' %}";
+        }, 2000);
+      }
+    })
+    .catch((error) => {
+      console.error("Error:", error);
+      showToast("Error submitting form. " + error.message);
+    });
   }
 
   function displayFormErrors(errors) {
@@ -192,7 +192,7 @@
         errorElement.style.display = "block";
         setTimeout(() => {
           errorElement.style.display = "none";
-        }, 2500);
+        }, 5000); // Increased duration for form error messages
       }
     });
   }


### PR DESCRIPTION
In ticket no.38 in profile page when add validation http error toast shown fix that issue without http error shown and slot list page this tested GCB and My local already success toast message shown
![Screenshot from 2024-07-24 15-04-03](https://github.com/user-attachments/assets/f0ff310c-9344-47fe-a71f-5eb118661e40)
![Screenshot from 2024-07-24 15-03-46](https://github.com/user-attachments/assets/ad2092a1-8d3f-4d14-8ed5-257f783ef943)
![Screenshot from 2024-07-24 14-48-29](https://github.com/user-attachments/assets/1f79dbe5-c067-4241-ba50-58d5e3689d00)
