### PR TITLE
fix toast mesage in book now

### DIFF
--- a/backend/frontend/src/screens/BookingInfoScreen.js
+++ b/backend/frontend/src/screens/BookingInfoScreen.js
@@ -342,11 +342,12 @@ function BookingInfoScreen() {
 
   useEffect(() => {
     if (userLoginSuccess && isLogin) {
-      toast.success(t("loggedInSuccessfully"));
-      setOpenForm(false);
-      setIsLogin(false);
+        toast.success(t("message", { userName: userInfo.first_name }), { duration: 4000 });
+        setOpenForm(false);
+        setIsLogin(false);
     }
-  }, [isLogin, userLoginSuccess]);
+}, [isLogin, userLoginSuccess, userInfo, t]);
+
 
   useEffect(() => {
     const userName = localStorage.getItem("userName");


### PR DESCRIPTION
![image2 booknow](https://github.com/user-attachments/assets/08ee357b-7920-43ce-8646-805354d438cb)
![image1 booknow](https://github.com/user-attachments/assets/04a45f4e-092a-4ca1-8696-f31e36249256)
In this ticket no.55 :-
-> In this ticket already sent to QA in this they given changes is when the book now is click before login it shows login popup shown. when add the username and password when we entered the have to show Loginsuccessfully with user name 
-> Fix the toast message with user name in booknow login
